### PR TITLE
feat: データベースをSQLiteに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,13 @@ GOROmanフォロワー5万人突破記念 Amazonギフト券プレゼントキ�
 
 - 言語：TypeScript
 - フレームワーク：Node.js
-- データベース：PostgreSQL（Prisma ORM）
+- データベース：SQLite（Prisma ORM）
 - API：Twitter API v2
 
 ## セットアップ
 
 ### 必要条件
 - Node.js 18.x以上
-- PostgreSQL 15.x以上
 - Twitter API v2アクセストークン
 
 ### インストール手順

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,7 @@
 // This is your Prisma schema file
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider = "sqlite"
+  url      = "file:./dev.db"
 }
 
 generator client {


### PR DESCRIPTION
## 変更内容

データベースをPostgreSQLからSQLiteに変更し、ローカルでの開発をより簡単にします。

### 主な変更点
- Prismaの設定をSQLiteに変更
  - データベースファイル: 
  - 環境変数の設定が不要に
- READMEの技術スタックを更新
- セットアップ要件からPostgreSQLを削除

### メリット
- セットアップが簡単に（PostgreSQLのインストールが不要）
- ローカル開発がより手軽に
- データベースファイルの共有が容易

### 影響範囲
- データベースのスキーマ定義は変更なし
- アプリケーションコードへの影響なし（Prisma抽象化レイヤーのおかげ）

### レビューのポイント
- SQLiteへの移行による制限事項がないか
- 開発フローに問題がないか