### PR TITLE
ログレベルの表記統一

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -50,7 +50,7 @@ export class Logger {
    * @param metadata メタデータ
    */
   private async log(
-    type: 'INFO' | 'ERROR' | 'WARN' | 'DEBUG',
+    type: 'INFO' | 'ERROR' | 'WARNING' | 'DEBUG',
     message: string,
     metadata?: Record<string, unknown>
   ): Promise<void> {


### PR DESCRIPTION
## 変更内容

- ログレベルの表記を統一（WARN → WARNING）

## 変更理由

- ログレベルの表記を一貫性のある形に統一し、可読性を向上

## テスト

- [ ] ユニットテスト
- [ ] E2Eテスト

## その他

- 破壊的変更: なし
- 影響範囲: ログ出力のみ