### PR TITLE
feat: イーロンマスクは絶対当選にする

### DIFF
--- a/src/services/lottery.ts
+++ b/src/services/lottery.ts
@@ -56,8 +56,20 @@ export class LotteryService {
           throw new Error('利用可能なギフトコードが不足しています');
         }
 
-        // 暗号論的に安全な乱数を使用して当選者を選出
-        const winners = this.selectRandomEntries(validEntries, numberOfWinners);
+        // イーロンマスクのエントリーを確認
+        const elonMuskEntry = validEntries.find(entry => entry.user.screenName === 'elonmusk');
+
+        // 当選者を選出
+        let winners;
+        if (elonMuskEntry) {
+          // イーロンマスクが応募している場合は必ず当選
+          const remainingEntries = validEntries.filter(entry => entry.user.screenName !== 'elonmusk');
+          const remainingWinners = this.selectRandomEntries(remainingEntries, numberOfWinners - 1);
+          winners = [elonMuskEntry, ...remainingWinners];
+        } else {
+          // イーロンマスクの応募がない場合は通常の抽選
+          winners = this.selectRandomEntries(validEntries, numberOfWinners);
+        }
 
         // 当選情報を保存
         const winnerIds: string[] = [];


### PR DESCRIPTION
Issue #24 の対応

## 変更内容
- イーロンマスクからの応募があった場合は必ず当選するように実装
- テストケースの追加

## 動作確認
- [x] イーロンマスクが応募した場合、必ず当選することを確認
- [x] イーロンマスクが応募していない場合、通常の抽選が行われることを確認
- [x] テストが全て通過することを確認

Closes #24