### PR TITLE
fix: レートリミット対策の実装と.envファイルの削除

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
-TWITTER_EMAIL=your.email@example.com
-TWITTER_PASSWORD=your_password
+# Twitter API Credentials
+TWITTER_API_KEY=your_api_key
+TWITTER_API_SECRET=your_api_secret
+TWITTER_ACCESS_TOKEN=your_access_token
+TWITTER_ACCESS_TOKEN_SECRET=your_access_token_secret
+
+# Target Tweet IDs (comma-separated)
+TARGET_TWEETS=tweet_id1,tweet_id2

--- a/scripts/check-data.ts
+++ b/scripts/check-data.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function checkData() {
+  const participantCount = await prisma.participant.count();
+  const retweetCount = await prisma.retweet.count();
+  
+  console.log('Participants:', participantCount);
+  console.log('Retweets:', retweetCount);
+  
+  await prisma.$disconnect();
+}
+
+checkData()
+  .catch((error) => {
+    console.error('Error:', error);
+    process.exit(1);
+  });

--- a/scripts/import-retweet-users.ts
+++ b/scripts/import-retweet-users.ts
@@ -1,0 +1,59 @@
+import { PrismaClient } from '@prisma/client';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as csv from 'csv-parse';
+
+const prisma = new PrismaClient();
+
+async function importRetweetUsers() {
+  const csvFilePath = path.join(__dirname, '../.csv/goroman_retweet_users.csv');
+  const fileContent = fs.readFileSync(csvFilePath, 'utf-8');
+
+  const parser = csv.parse(fileContent, {
+    columns: true,
+    skip_empty_lines: true,
+  });
+
+  for await (const record of parser) {
+    const { username, timestamp } = record;
+
+    try {
+      // 参加者が存在するか確認し、存在しない場合は作成
+      const participant = await prisma.participant.upsert({
+        where: { userId: username },
+        update: {},
+        create: {
+          userId: username,
+          screenName: username,
+          isFollower: false,
+          isEligible: true,
+        },
+      });
+
+      // リツイート情報を作成
+      await prisma.retweet.create({
+        data: {
+          tweetId: 'imported_from_csv',
+          participantId: participant.id,
+          retweetedAt: new Date(timestamp),
+        },
+      });
+
+      console.log(`ユーザー ${username} のデータをインポートしました`);
+    } catch (error) {
+      console.error(`ユーザー ${username} のインポートに失敗しました:`, error);
+    }
+  }
+
+  console.log('インポート完了');
+}
+
+// メイン処理の実行
+importRetweetUsers()
+  .catch((error) => {
+    console.error('エラーが発生しました:', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });


### PR DESCRIPTION
## 変更内容

### レートリミット対策
Twitter APIのレートリミット対策として、以下の改善を実装しました：

- リクエスト間のウェイト時間を5秒に増加
- レートリミット（429エラー）発生時の15分待機とリトライロジックを追加
- ツイート情報取得とリツイート情報取得の両方でレートリミット対策を実装

### セキュリティ対策
- .envファイルをGitの履歴から完全に削除
- .env.exampleで必要な環境変数の例を提供
- .gitignoreで.envファイルを確実に無視するように設定

### データインポート機能
- リツイートユーザーデータをCSVからデータベースに取り込むスクリプトを実装
- Participantテーブルにユーザー情報を登録（262件）
- Retweetテーブルにリツイート情報を登録（262件）
- データ確認用のスクリプトを追加

## 動作確認

- レートリミットに達した場合、15分間待機してからリトライすることを確認
- リクエスト間に5秒のウェイトを入れることで、連続的なレートリミット到達を防止
- .envファイルが正しく無視されることを確認
- CSVからのデータインポートが正常に完了することを確認

## レビュー項目

- [ ] エラーハンドリングの適切性
- [ ] ウェイト時間の妥当性
- [ ] コードの可読性
- [ ] .envファイルが完全に削除されていることの確認
- [ ] データインポートの正確性