### PR TITLE
抽選システムの改善

### DIFF
--- a/.github/workflows/lottery.yml
+++ b/.github/workflows/lottery.yml
@@ -19,6 +19,9 @@ jobs:
   # 抽選処理の実行
   draw:
     runs-on: ubuntu-latest
+    # GitHubトークンの権限設定
+    permissions:
+      contents: write # リリース作成に必要な権限
     
     steps:
       # リポジトリのチェックアウト

--- a/.github/workflows/lottery.yml
+++ b/.github/workflows/lottery.yml
@@ -49,8 +49,8 @@ jobs:
       # 抽選の実行
       - name: 抽選の実行
         run: |
-          # 抽選結果をテキスト形式で保存
-          npx ts-node scripts/campaign-manager.ts > lottery-result.txt
+          # 抽選結果を標準出力とファイルの両方に出力
+          npx ts-node scripts/campaign-manager.ts | tee lottery-result.txt
         env:
           DATABASE_URL: "file:./prisma/dev.db"
           SEED_VALUE: ${{ github.event.inputs.seed }}

--- a/scripts/campaign-manager.ts
+++ b/scripts/campaign-manager.ts
@@ -115,9 +115,9 @@ async function main(): Promise<void> {
       await sleep(2000); // 2秒待機
       console.log(`Xフォロワー名: @${winner.screenName}`);
       await sleep(2000); // 2秒待機
-      console.log('\nDMメッセージ:');
       console.log(winner.dmMessage);
       console.log('----------------------------------------------------------------------');
+      await sleep(2000); // 2秒待機
     }
     
     console.log(`\n抽選完了: ${winners.length}名の当選者を選出しました。`);

--- a/scripts/campaign-manager.ts
+++ b/scripts/campaign-manager.ts
@@ -109,11 +109,12 @@ async function main(): Promise<void> {
 
     // 当選者リストの出力
     console.log('\n=== 当選者リスト ===');
-    await sleep(2000); // 2秒待機
 
     winnersList.forEach((winner, index) => {
       console.log(`[当選者 ${index + 1}]`);
+      await sleep(2000); // 2秒待機
       console.log(`Xフォロワー名: @${winner.screenName}`);
+      await sleep(2000); // 2秒待機
       console.log('\nDMメッセージ:');
       console.log(winner.dmMessage);
       console.log('----------------------------------------------------------------------');

--- a/scripts/campaign-manager.ts
+++ b/scripts/campaign-manager.ts
@@ -26,7 +26,7 @@ Object.entries(config).forEach(([key, value]) => {
 
 // DM送信用のメッセージを生成
 function generateDMMessage(giftCode: string): string {
-  return `🎉おめでとうございます！\nGOROmanフォロワー5万人突破記念キャンペーンに当選しました！\n\nAmazonギフト券（${config.giftAmount}円分）\n\nご参加ありがとうございました！`;
+  return `\n🎉おめでとうございます！\nGOROmanフォロワー5万人突破記念キャンペーンに当選しました！\n\nAmazonギフト券（${config.giftAmount}円分）\n\nご参加ありがとうございました！`;
 }
 
 // シード値に基づく乱数生成器クラス
@@ -104,20 +104,22 @@ async function main(): Promise<void> {
       };
     });
     
+    // 2秒待機する関数
+    const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
     // 当選者リストの出力
     console.log('\n=== 当選者リスト ===');
+    await sleep(2000); // 2秒待機
+
     winnersList.forEach((winner, index) => {
-      console.log(`\n[当選者 ${index + 1}]`);
-      console.log(`ユーザーID: ${winner.userId}`);
-      console.log(`スクリーンネーム: ${winner.screenName}`);
-      console.log(`ギフトコード: ${winner.giftCode}`);
+      console.log(`[当選者 ${index + 1}]`);
+      console.log(`Xフォロワー名: @${winner.screenName}`);
       console.log('\nDMメッセージ:');
       console.log(winner.dmMessage);
-      console.log('---');
+      console.log('----------------------------------------------------------------------');
     });
     
     console.log(`\n抽選完了: ${winners.length}名の当選者を選出しました。`);
-    console.log('当選者へのDM送信は手動で行ってください。');
   } catch (error) {
     console.error('エラーが発生しました:', error);
   } finally {

--- a/scripts/campaign-manager.ts
+++ b/scripts/campaign-manager.ts
@@ -110,7 +110,7 @@ async function main(): Promise<void> {
     // 当選者リストの出力
     console.log('\n=== 当選者リスト ===');
 
-    winnersList.forEach((winner, index) => {
+    for (const [index, winner] of winnersList.entries()) {
       console.log(`[当選者 ${index + 1}]`);
       await sleep(2000); // 2秒待機
       console.log(`Xフォロワー名: @${winner.screenName}`);
@@ -118,7 +118,7 @@ async function main(): Promise<void> {
       console.log('\nDMメッセージ:');
       console.log(winner.dmMessage);
       console.log('----------------------------------------------------------------------');
-    });
+    }
     
     console.log(`\n抽選完了: ${winners.length}名の当選者を選出しました。`);
   } catch (error) {


### PR DESCRIPTION
## 変更内容

1. GitHub Actionsのワークフローにリリース作成権限を追加
   - `contents: write` 権限を設定
   - リリース作成時の403エラーを解消

2. 抽選結果の出力形式を改善
   - 標準出力とファイルの両方に結果を出力するように変更（`tee` コマンドを使用）
   - 出力フォーマットを見やすく整理
   - DMメッセージの区切り線を統一

3. 不要な出力を削除
   - ユーザーIDとギフトコードの表示を削除
   - 手動DM送信の注意書きを削除

4. 抽選結果の表示を改善
   - 当選者情報の表示に2秒のディレイを追加
   - `forEach` を `for...of` に変更してasync/awaitをサポート
   - 各当選者の情報をゆっくりと表示することで可読性を向上